### PR TITLE
Fix: 유저네임 정규식 수정, 제일 많이 사용한 언어 최대 6개까지 노출로 변경

### DIFF
--- a/yearend/src/components/Result.jsx
+++ b/yearend/src/components/Result.jsx
@@ -25,6 +25,7 @@ function Result({
     res2024[e.name] = e.counts;
   });
   const { sortedDate, sortedLang, sortedRepo } = mostof2024;
+  const countedLang = sortedLang.slice(0, 6);
 
   const resRef = useRef();
   const res = resRef.current;
@@ -80,18 +81,18 @@ function Result({
         <div>
           <span>🏆 올해 자주 사용한 언어 순위</span>는 아래와 같아요.
           <ol>
-            {sortedLang.slice(0, 3).map((ele, ind) => (
+            {countedLang.slice(0, 3).map((ele, ind) => (
               <li key={ind}>
                 <span>{ele.name}</span>
               </li>
             ))}
-            {sortedLang.length > 3 && (
+            {countedLang.length > 3 && (
               <li>
                 {'그 외 '}
-                {sortedLang.slice(3).map((ele, ind) => (
+                {countedLang.slice(3).map((ele, ind) => (
                   <span key={ind}>
                     {ele.name}
-                    {ind < sortedLang.slice(3).length - 2 ? ', ' : ''}
+                    {ind < 2 ? ', ' : ''}
                   </span>
                 ))}
                 {' ...'}

--- a/yearend/src/utils/functions.js
+++ b/yearend/src/utils/functions.js
@@ -10,7 +10,7 @@ export const checkExistID = async (str) => {
 };
 
 export const validateID = (str) => {
-  const reg = /^[A-Za-z0-9]{4,39}$/;
+  const reg = /^[A-Za-z0-9_-]{4,39}$/;
   const regKor = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/;
 
   if (!reg.test(str)) {


### PR DESCRIPTION
### 1. #25 username - 포함된 문자열 인식 안됨
- username 입력시 - 가 포함된 이름은 정규식에서 통과하지 못하여 알럿이 뜨는 상황
- _- 2개 정규식에 추가

|BEFORE|AFTER|
|--|--|
|`const reg = /^[A-Za-z0-9]{4,39}$/;`|`const reg = /^[A-Za-z0-9_-]{4,39}$/;`

### 2. #27 3위 이후 그 외 부분 최대 3개 언어까지 노출되게 변경
- 자주 사용한 언어 최대 10개까지 노출되고 있어 3위 이후 + 최대 6개까지만 노출되게 변경

|BEFORE|AFTER|
|--|--|
|<img width="717" alt="image" src="https://github.com/user-attachments/assets/8d47e7fa-b657-4a8f-b8f8-c0c921574d9f" />|<img width="719" alt="image" src="https://github.com/user-attachments/assets/c3f3920a-341c-4d17-877b-0cda8554c3c4" />|
